### PR TITLE
Close file before removing to satisfy Windows requirements - Linked: #27

### DIFF
--- a/src/rich_codex/rich_img.py
+++ b/src/rich_codex/rich_img.py
@@ -509,11 +509,11 @@ class RichImg:
                 continue
 
             # Set filenames
-            tmp_filename = mkstemp()[1]
+            tmp_file_handle, tmp_filename = mkstemp()
 
             # We always generate an SVG first
             if svg_img is None:
-                svg_tmp_filename = mkstemp()[1]
+                svg_tmp_file_handle, svg_tmp_filename = mkstemp()
                 self.capture_console.save_svg(
                     svg_tmp_filename,
                     title=self.title,
@@ -574,9 +574,11 @@ class RichImg:
             # Delete temprary files
             tmp_path = Path(tmp_filename)
             if Path(gettempdir()) in tmp_path.resolve().parents:
+                os.close(tmp_file_handle)
                 tmp_path.unlink()
 
         # Delete temporary SVG file - after loop as can be reused
         tmp_svg_path = Path(svg_tmp_filename)
         if Path(gettempdir()) in tmp_svg_path.resolve().parents:
+            os.close(svg_tmp_file_handle)
             tmp_svg_path.unlink()


### PR DESCRIPTION
## Description:
As illustrated in #27, this PR adds the `os.close(...)` to handle closing files before attempting to remove them to satisfy Windows requirements. From local testing, this solves the observed issue, quite nicely.

## Changes:
* Add `os.close(...)` for both the temporary file and temporary SVG file.

## Linked Issues:
* Closes #27

## Closing Thoughts:
* I was unable to get pre-commit working on my system. Ended up having a number of failures that prevented the commit. So this PR might need an extra-close review to make sure the formatting requirements, etc., are met in the way that you want.
* THANK YOU, for this AWESOME project! It's wonderful!!!