### PR TITLE
Left align entries in `Source` column of output table

### DIFF
--- a/src/rich_codex/codex_search.py
+++ b/src/rich_codex/codex_search.py
@@ -359,11 +359,11 @@ class CodexSearch:
         for img_obj in self.rich_imgs:
             if img_obj.command is not None:
                 try:
-                    rel_source = Path(img_obj.source).absolute().relative_to(Path.cwd().absolute())
+                    rel_source = Path(img_obj.source).resolve().relative_to(Path.cwd().resolve())
                 except ValueError:
                     log.debug("Couldn't find relative path")
                     rel_source = img_obj.source
-                source = f" [grey42][link=file:{Path(img_obj.source).absolute()}]{rel_source}[/][/]"
+                source = f" [grey42][link=file:{Path(img_obj.source).resolve()}]{rel_source}[/][/]"
                 table.add_row(img_obj.command, source)
 
         if table.row_count == 0:

--- a/src/rich_codex/codex_search.py
+++ b/src/rich_codex/codex_search.py
@@ -363,7 +363,7 @@ class CodexSearch:
                 except ValueError:
                     log.debug("Couldn't find relative path")
                     rel_source = img_obj.source
-                source = f" [grey42][link=file:{Path(img_obj.source).resolve()}]{rel_source}[/][/]"
+                source = f"[grey42][link=file:{Path(img_obj.source).resolve()}]{rel_source}[/][/]"
                 table.add_row(img_obj.command, source)
 
         if table.row_count == 0:


### PR DESCRIPTION
## Overview

This PR attempts to improve the output a bit. In particular, it removes the extra leading space in the `Source` column output. This extra space character appears to be a mistake. It was causing the output values in that column to not be aligned with the table's column header.

Additionally, the uses of `pathlib.Path.absolute()` were replaced with `pathlib.Path.resolve()`. The Python standard library `pathlib` provides a method, `Path.absolute()`, that is [undocumented](https://devdocs.io/python~3.7/library/pathlib) and does not perform normalization. The docstring on the method (e.g., `help(pathlib.Path.absolute)` even suggests using `.resolve()` instead:

```console
❯ python
Python 3.10.5 (main, Jul  1 2022, 15:55:06) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pathlib
>>> help(pathlib.Path.absolute)
Help on function absolute in module pathlib:

absolute(self)
    Return an absolute version of this path.  This function works
    even if the path doesn't point to anything.

    No normalization is done, i.e. all '.' and '..' will be kept along.
    Use resolve() to get the canonical path to a file.

>>> help(pathlib.Path.resolve)
Help on function resolve in module pathlib:

resolve(self, strict=False)
    Make the path absolute, resolving all symlinks on the way and also
    normalizing it (for example turning slashes into backslashes under
    Windows).
```


## Screenshots

Extra space in the `Source` entries column:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/18729796/186259084-06d34981-b158-4864-a217-7dc02c3bca16.png">

---

With the space removed:

<img width="568" alt="image" src="https://user-images.githubusercontent.com/18729796/186259274-6a242a17-37cc-4c24-982a-177a1e186538.png">
