### PR TITLE
update cli, gh action, and docs to include all features

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   timeout:
     description: Maximum run time for command (seconds)
     required: false
+  working_dir:
+    description: Working directory to run command in (relative to root of project)
+    required: false
   before_command:
     description: Setup commands to run before running main output command
     required: false
@@ -128,6 +131,7 @@ runs:
         NO_SEARCH: ${{ inputs.no_search }}
         COMMAND: ${{ inputs.command }}
         TIMEOUT: ${{ inputs.timeout }}
+        WORKING_DIR: ${{ inputs.working_dir }}
         BEFORE_COMMAND: ${{ inputs.before_command }}
         AFTER_COMMAND: ${{ inputs.after_command }}
         SNIPPET: ${{ inputs.snippet }}

--- a/docs/config/overview.md
+++ b/docs/config/overview.md
@@ -21,17 +21,21 @@ They are, in order of parsing / precidence (last location wins):
 An overview of all available config options in all scopes is below:
 
 | CLI                    | Environment variable | GitHub Action / Rich-codex config |
-| ---------------------- | -------------------- | --------------------------------- |
+|------------------------|----------------------|-----------------------------------|
 | `--search-include`     | `SEARCH_INCLUDE`     | `search_include`                  |
 | `--search-exclude`     | `SEARCH_EXCLUDE`     | `search_exclude`                  |
 | `--no-search`          | `NO_SEARCH`          | `no_search`                       |
 | `--command`            | `COMMAND`            | `command`                         |
 | `--timeout`            | `TIMEOUT`            | `timeout`                         |
+| `--working-dir`        | `WORKING_DIR`        | `working_dir`                     |
+| `--before-command`     | `BEFORE_COMMAND`     | `before_command`                  |
+| `--after-command`      | `AFTER_COMMAND`      | `after_command`                   |
 | `--snippet`            | `SNIPPET`            | `snippet`                         |
 | `--snippet-syntax`     | `SNIPPET_SYNTAX`     | `snippet_syntax`                  |
 | `--img-paths`          | `IMG_PATHS`          | `img_paths`                       |
 | `--clean-img-paths`    | `CLEAN_IMG_PATHS`    | `clean_img_paths`                 |
 | `--configs`            | `RC_CONFIGS`         | `rc_configs`                      |
+| `--fake-command`       | `FAKE_COMMAND`       | `fake_command`                    |
 | `--hide-command`       | `HIDE_COMMAND`       | `hide_command`                    |
 | `--title-command`      | `TITLE_COMMAND`      | `title_command`                   |
 | `--head`               | `RC_HEAD`            | `head`                            |
@@ -48,14 +52,14 @@ An overview of all available config options in all scopes is below:
 | `--terminal-theme`     | `TERMINAL_THEME`     | `terminal_theme`                  |
 | `--snippet-theme`      | `SNIPPET_THEME`      | `snippet_theme`                   |
 | `--use-pty`            | `USE_PTY`            | `use_pty`                         |
-| `--created-files`      | `CREATED_FILES`      | `-`                               |
-| `--deleted-files`      | `DELETED_FILES`      | `-`                               |
+| `--created-files`      | `CREATED_FILES`      | -                                 |
+| `--deleted-files`      | `DELETED_FILES`      | -                                 |
 | `--verbose`            | `LOG_VERBOSE`        | `log_verbose` \*                  |
 | `--save-log`           | `LOG_SAVE`           | -                                 |
 | `--log-file`           | `LOG_FILENAME`       | -                                 |
 | -                      | -                    | `commit_changes` \*               |
 | -                      | -                    | `error_changes` \*                |
-| -                      | -                    | `title` †                         |
+| -                      | -                    | `title` †                         |
 | -                      | -                    | `extra_env` †                     |
 | -                      | -                    | `skip` †                          |
 

--- a/docs/config/overview.md
+++ b/docs/config/overview.md
@@ -9,9 +9,9 @@ They are, in order of parsing / precidence (last location wins):
     - GitHub Action arguments
     - Environment variables
     - Command-line flags (CLI)
-    - Rich-codex config files
+    - Rich-codex config files (`.rich-codex.yml`)
 - Per-image:
-    - Rich-codex config files
+    - Rich-codex config files (`.rich-codex.yml`)
     - Markdown config
 
 <!-- prettier-ignore-end -->

--- a/docs/config/overview.md
+++ b/docs/config/overview.md
@@ -21,7 +21,7 @@ They are, in order of parsing / precidence (last location wins):
 An overview of all available config options in all scopes is below:
 
 | CLI                    | Environment variable | GitHub Action / Rich-codex config |
-|------------------------|----------------------|-----------------------------------|
+| ---------------------- | -------------------- | --------------------------------- |
 | `--search-include`     | `SEARCH_INCLUDE`     | `search_include`                  |
 | `--search-exclude`     | `SEARCH_EXCLUDE`     | `search_exclude`                  |
 | `--no-search`          | `NO_SEARCH`          | `no_search`                       |

--- a/docs/inputs/config_file.md
+++ b/docs/inputs/config_file.md
@@ -54,3 +54,78 @@ outputs:
 
 There are many other config keys also available.
 See the [configuration docs](../config/overview.md) for more details.
+
+### Install IDE Validation
+
+You can validate your `.rich-codex.yml` files in your IDEs using JSONSchema.
+
+#### VSCode
+
+1. Install the [VSCode-YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+
+2. In your repo, create a `.vscode/settings.jsonc` or `.vscode/settings.template.jsonc` file containing the following data. This is what tells the extension which schema to associate with each file.
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/ewels/rich-codex/main/src/rich_codex/config-schema.yml": [
+      ".rich-codex.yml",
+      ".rich-codex.yaml"
+    ]
+  }
+}
+```
+
+3. To prompt other users to install the YAML extension, create a `.vscode/extensions.json` file containing the following data inside your repo:
+
+```json
+{
+  "recommendations": ["redhat.vscode-yaml"]
+}
+```
+
+#### JetBrains (PyCharm, IntelliJ, etc.)
+
+There are two ways to set this up.
+
+You can either add the following data to your `.idea/jsonSchemas.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="rich_codex">
+          <value>
+            <SchemaInfo>
+              <option name="generatedName" value="New Schema" />
+              <option name="name" value="rich-codex" />
+              <option name="relativePathToSchema" value="https://raw.githubusercontent.com/ewels/rich-codex/main/src/rich_codex/config-schema.yml" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="path" value=".rich-codex.yml" />
+                  </Item>
+                  <Item>
+                    <option name="path" value=".rich-codex.yaml" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>
+```
+
+Or you can do this manually in **Preferences > Languages & Frameworks > Schemas and DTDs > Json Schema Mappings**:
+
+- **Name**: `rich-codex`
+- **Schema File or URL**: `https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/dbt_project.json`
+- **Schema Version:** JSON schema version 4
+- **Mappings**:
+  - `.rich-codex.yml`
+  - `.rich-codex.yaml`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,4 +62,5 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.details
 plugins:
+  - search
   - social

--- a/src/rich_codex/cli.py
+++ b/src/rich_codex/cli.py
@@ -53,6 +53,12 @@ log = logging.getLogger()
     help="Maximum run time for command (seconds)",
 )
 @click.option(
+    "--working-dir",
+    envvar="WORKING_DIR",
+    show_envvar=True,
+    help="Working directory to run command in",
+)
+@click.option(
     "--before-command",
     envvar="BEFORE_COMMAND",
     show_envvar=True,
@@ -255,6 +261,7 @@ def main(
     no_search,
     command,
     timeout,
+    working_dir,
     before_command,
     after_command,
     snippet,
@@ -376,6 +383,7 @@ def main(
             timeout=timeout,
             before_command=before_command,
             after_command=after_command,
+            working_dir=working_dir,
             fake_command=fake_command,
             hide_command=hide_command,
             title_command=title_command,

--- a/src/rich_codex/codex_search.py
+++ b/src/rich_codex/codex_search.py
@@ -30,6 +30,7 @@ class CodexSearch:
         no_confirm,
         snippet_syntax,
         timeout,
+        working_dir,
         before_command,
         after_command,
         hide_command,
@@ -53,12 +54,20 @@ class CodexSearch:
         self.search_exclude = ["**/.git*", "**/.git*/**", "**/node_modules/**"]
         if search_exclude is not None:
             self.search_exclude.extend(self._clean_list(search_exclude.splitlines()))
-        self.configs = [".rich-codex.yml", ".github/rich-codex.yml", "docs/img/rich-codex.yml"]
+        self.configs = [
+            ".rich-codex.yml",
+            ".rich-codex.yaml",
+            ".github/rich-codex.yml",
+            ".github/rich-codex.yaml",
+            "docs/img/rich-codex.yml",
+            "docs/img/rich-codex.yaml",
+        ]
         if configs is not None:
             self.configs.extend(self._clean_list(configs.splitlines()))
         self.no_confirm = no_confirm
         self.snippet_syntax = snippet_syntax
         self.timeout = timeout
+        self.working_dir = working_dir
         self.before_command = before_command
         self.after_command = after_command
         self.hide_command = hide_command
@@ -83,6 +92,7 @@ class CodexSearch:
         self.class_config_attrs = [
             "snippet_syntax",
             "timeout",
+            "working_dir",
             "before_command",
             "after_command",
             "hide_command",

--- a/src/rich_codex/config-schema.yml
+++ b/src/rich_codex/config-schema.yml
@@ -10,6 +10,7 @@ properties:
   # Shared config options
   snippet_syntax: { "$ref": "#/$defs/snippet_syntax" }
   timeout: { "$ref": "#/$defs/timeout" }
+  working_dir: { "$ref": "#/$defs/working_dir" }
   before_command: { "$ref": "#/$defs/before_command" }
   after_command: { "$ref": "#/$defs/after_command" }
   hide_command: { "$ref": "#/$defs/hide_command" }
@@ -56,8 +57,6 @@ properties:
           type: string
           message:
             required: Either command or snippet is required
-        working_dir:
-          title: Working directory to run command in
         snippet:
           title: Code snippet to use
           type: string
@@ -89,6 +88,7 @@ properties:
         # Shared config options
         snippet_syntax: { "$ref": "#/$defs/snippet_syntax" }
         timeout: { "$ref": "#/$defs/timeout" }
+        working_dir: { "$ref": "#/$defs/working_dir" }
         before_command: { "$ref": "#/$defs/before_command" }
         after_command: { "$ref": "#/$defs/after_command" }
         hide_command: { "$ref": "#/$defs/hide_command" }
@@ -114,6 +114,9 @@ properties:
   timeout:
     title: Maximum run time for command (seconds)
     type: integer
+  working_dir:
+    title: Working directory to run command in
+    type: string
   before_command:
     title: Setup commands to run before running main output command
     type: string


### PR DESCRIPTION
I'm updating `rich-click` docs right now.

Having `working_dir:` as an option in the Github Actions would be extremely helpful. For now I need to do either 
`<!-- RICH-CODEX working_dir: . -->` or use a `fake_command` on literally every command in the docs to make it work the way I want. Adding `working_dir: "."` to the GH action would be great.

While I was at it, I also updated the table to reflect everything available in the CLI, as I noticed it wasn't in parity.

---

Update: won't use these for rich-click docs after all, but they're still good changes.