### PR TITLE
fix missing required argument error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog: rich-codex
 
+## Version 1.2.10
+
+- 🐛 Fix missing required argument ([#53](https://github.com/ewels/rich-codex/pull/53))
+
 ## Version 1.2.8
 
 - ✨ Update upload-artifact action to v4 ([#49](https://github.com/ewels/rich-codex/pull/49))

--- a/src/rich_codex/cli.py
+++ b/src/rich_codex/cli.py
@@ -444,6 +444,7 @@ def main(
         snippet_theme=snippet_theme,
         use_pty=use_pty,
         console=console,
+        working_dir=working_dir,
     )
     try:
         codex_obj.parse_configs()


### PR DESCRIPTION
Hello, I encountered an error when trying to use the new 1.2.9 version, this should fix it 🙂 