### PR TITLE
Don't validate working_dir as a string

### DIFF
--- a/src/rich_codex/config-schema.yml
+++ b/src/rich_codex/config-schema.yml
@@ -116,7 +116,6 @@ properties:
     type: integer
   working_dir:
     title: Working directory to run command in
-    type: string
   before_command:
     title: Setup commands to run before running main output command
     type: string


### PR DESCRIPTION
I see the validation of `working_dir` was added to 1.2.9 with https://github.com/ewels/rich-codex/commit/634a4800e82c26425e1ecbde980710ed986fc4e5
The error we see is that it can't validate a python Path as a string. Removing this validation fixes the error, and rich-codex can run. I am not sure if there is a better way to fix this and still allow the validation of working_dir